### PR TITLE
Feat/service worker builder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
   "extends": "vtex",
-  "root": true
+  "root": true,
+  "env":{
+    "browser": true
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.1] - 2020-08-11
 ### Fixed
 - Updated README.md file
-- Added service-worker support
 
 ## [1.0.0] - 2020-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Service Worker Builder compatibility
 
 ## [1.0.1] - 2020-08-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.1] - 2020-08-11
 ### Fixed
 - Updated README.md file
+- Added service-worker support
 
 ## [1.0.0] - 2020-07-27
 

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
   "builders": {
     "node": "6.x",
     "docs": "0.x",
-    "pixel": "0.x"
+    "pixel": "0.x",
+    "service-worker": "0.x"
   },
   "credentialType": "absolute",
   "policies": [

--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "@types/jest": "^24.0.18",
     "@types/node": "^12.0.0",
     "@types/ramda": "^0.27.12",
-    "@vtex/api": "6.40.0",
+    "@vtex/api": "6.41.0",
     "@vtex/test-tools": "^3.0.0",
     "@vtex/tsconfig": "^0.4.4",
     "typescript": "3.9.7"

--- a/node/package.json
+++ b/node/package.json
@@ -8,10 +8,10 @@
     "@types/jest": "^24.0.18",
     "@types/node": "^12.0.0",
     "@types/ramda": "^0.27.12",
-    "@vtex/api": "6.35.2",
+    "@vtex/api": "6.40.0",
     "@vtex/test-tools": "^3.0.0",
     "@vtex/tsconfig": "^0.4.4",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "scripts": {
     "lint": "tsc --noEmit --pretty"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1618,14 +1618,14 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.35.2":
-  version "6.35.2"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.35.2.tgz#7b6f20295c13863bc9c9e3af82c5b12a861c27f8"
-  integrity sha512-FOOzGa2krqUHc0IHsgazlZzsml2EL1DzqDyiVmvnuWFN0Xf+FT06Ppoil77fIGPhaEfLNsmX3uUYXXsQA9W4gQ==
+"@vtex/api@6.40.0":
+  version "6.40.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.40.0.tgz#830c4aaaad75a1a8cf86ce898010e081a89053f8"
+  integrity sha512-VDdg9KVoNQ6KxH6cM0Tgh+VF7ELLrORqk5lRaie4akUZXW2tqECFLZAvRi9UE29CLstqCLBGQjqxbuT1aj/mgQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
-    "@vtex/node-error-report" "^0.0.2"
+    "@vtex/node-error-report" "^0.0.3"
     "@wry/equality" "^0.1.9"
     agentkeepalive "^4.0.2"
     apollo-server-errors "^2.2.1"
@@ -1663,10 +1663,10 @@
     uuid "^3.3.3"
     xss "^1.0.6"
 
-"@vtex/node-error-report@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/@vtex/node-error-report/-/node-error-report-0.0.2.tgz#edf15095d6bb543d28b46f86bc109e6214149dfe"
-  integrity sha512-Q6V8E1IR/U0H6uTB1G+gH4ugL4Kw1l/WsK7W46LQBsxv4ISlZcO7dXPlWrL4RzRcVam5yzGAwNkv2wJdW61tAA==
+"@vtex/node-error-report@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.3.tgz#365a2652aeebbd6b51ddc5d64c3c0bc1a326dc71"
+  integrity sha512-HhBworWQfSs6PU3yroloc7H2/pWboDIzgdiJ6SYc3mJVRU5/bXtwM9HGPkAGZvAb/0cMwFC963SYYKvOfeSjbA==
   dependencies:
     is-stream "^2.0.0"
 
@@ -5663,7 +5663,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -6010,12 +6010,7 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.7.3:
+typescript@3.9.7, typescript@^3.7.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1618,10 +1618,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.40.0":
-  version "6.40.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.40.0.tgz#830c4aaaad75a1a8cf86ce898010e081a89053f8"
-  integrity sha512-VDdg9KVoNQ6KxH6cM0Tgh+VF7ELLrORqk5lRaie4akUZXW2tqECFLZAvRi9UE29CLstqCLBGQjqxbuT1aj/mgQ==
+"@vtex/api@6.41.0":
+  version "6.41.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.41.0.tgz#cee074ff49de8a5de92f3d353a4689275cb92f7b"
+  integrity sha512-RvfdpczsxCFacZkDSl2v2NmfD/bHFxHHn2xQsEwSQ+40snGxfOz56TlCbPbgMEtkC8Bf+1GGUkCIChRE6xnlLg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/service-workers/header.js
+++ b/service-workers/header.js
@@ -1,0 +1,3 @@
+function oneSignalSWHeader() {
+  importScripts("https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js");
+}

--- a/service-workers/header.js
+++ b/service-workers/header.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 function oneSignalSWHeader() {
-  importScripts(`https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js`);
+  importScripts(`https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js`)
 }

--- a/service-workers/header.js
+++ b/service-workers/header.js
@@ -1,3 +1,4 @@
+ /* eslint-disable */
 function oneSignalSWHeader() {
-  importScripts("https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js");
+  importScripts(`https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js`);
 }

--- a/service-workers/header.js
+++ b/service-workers/header.js
@@ -1,4 +1,3 @@
- /* eslint-disable */
 function oneSignalSWHeader() {
   importScripts(`https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js`);
 }

--- a/service-workers/header.js
+++ b/service-workers/header.js
@@ -1,4 +1,6 @@
-/* eslint-disable */
 function oneSignalSWHeader() {
+  // eslint-disable-next-line no-undef
   importScripts(`https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js`)
 }
+
+export default oneSignalSWHeader


### PR DESCRIPTION
#### What does this PR do? \*

This PR introduces compatibility of OneSignal with the Service Worker Builder Implemented on `builder-hub`. Such builder is intended to wrap up the `service-workers` folder to expose the OneSignal Service Worker to the `service-worker-graphql` API.

#### How to test it? \*

See Service Worker Builder documentation (in process 😄 ).

#### Related to / Depends on \*
- [builder-hub](https://github.com/vtex/builder-hub)
